### PR TITLE
Bugfix/vehicle list text overflow

### DIFF
--- a/app/src/main/res/layout/vehicle_list_item.xml
+++ b/app/src/main/res/layout/vehicle_list_item.xml
@@ -37,7 +37,7 @@
                 android:textAppearance="?android:attr/textAppearanceMedium"
                 android:text="Medium Text"
                 android:id="@+id/targetDestination"
-                android:gravity="center_vertical|center_horizontal"
+                android:gravity="center_vertical"
                 android:layout_alignParentTop="true"
                 android:layout_toEndOf="@+id/busNumber"
                 android:layout_gravity="center_horizontal"


### PR DESCRIPTION
Fixed the bug for the trello card "Weird styling when the destination name overflows and gets a line break in it. See stop Pärlstickaregatan for example". The textView with the destination now takes the remaining space after time until arrival and line number is created. If the text overflows it's replaced with a "...".
